### PR TITLE
minor x86_64 syntax errors

### DIFF
--- a/knownconfigurations.sh
+++ b/knownconfigurations.sh
@@ -52,7 +52,7 @@ x86_64 ()
 	# Wants to download latest file..
 	file=archlinux-bootstrap-2017.11.01-x86_64.tar.gz
 	mirror=mirrors.evowise.com
-	path=/archlinux/iso/latest
+	path=/archlinux/iso/latest/
 	makesystem 
 }
 

--- a/necessaryfunctions.sh
+++ b/necessaryfunctions.sh
@@ -140,7 +140,7 @@ makesystem ()
 preproot ()
 {
 	if [ "$(uname -m)" = "x86_64" ] || [ "$(uname -m)" = "i686" ];then
-		proot --link2symlink bsdtar -xpf --strip-components 1 $file 2>/dev/null||:
+		proot --link2symlink bsdtar -xpf $file --strip-components 1 2>/dev/null||:
 	else
 		proot --link2symlink bsdtar -xpf $file 2>/dev/null||:
 	fi


### PR DESCRIPTION
While trying to install TermuxArch on a x86_64 Android tablet, I ran into 2 errors in the script itself (I ran into a 3rd issue, but it isn't directly a problem with the script, but with proot), both of which where minor syntax errors. Correcting these seemed to fix the install script (except proot threw me any error)

TL;DR I fixed some syntax issues