### PR TITLE
Initialisation of keys for pacman

### DIFF
--- a/setupTermuxArch.sh
+++ b/setupTermuxArch.sh
@@ -728,3 +728,5 @@ else
 	printusage
 fi
 printtail 
+pacman-key --init
+pacman-key --populate archlinuxarm


### PR DESCRIPTION
Without these two rows
```
pacman-key --init
pacman-key --populate archlinuxarm
```
I must print it by my hands. Why? It can be made along running install script.
See [issue 86](https://github.com/sdrausty/TermuxArch/issues/86)