### PR TITLE
append Termux's PATH to the end of TermuxArch's PATH

### DIFF
--- a/knownconfigurations.bash
+++ b/knownconfigurations.bash
@@ -90,7 +90,7 @@ _PR00TSTRING_() {
        	fi
        	PROOTSTMNT+="-b /proc/self/fd/1:/dev/stdout "
        	PROOTSTMNT+="-b /proc/self/fd/2:/dev/stderr "
-       	PROOTSTMNT+="-b \"\$ANDROID_DATA\" -b /dev/ -b \"\$EXTERNAL_STORAGE\" -b \"\$HOME\" -b /proc/ -b /storage/ -b /sys/ -w \"\$PWD\" /usr/bin/env -i HOME=/root TERM=$TERM ANDROID_DATA=/data"
+       	PROOTSTMNT+="-b \"\$ANDROID_DATA\" -b /dev/ -b \"\$EXTERNAL_STORAGE\" -b \"\$HOME\" -b /proc/ -b /storage/ -b /sys/ -w \"\$PWD\" /usr/bin/env -i HOME=/root TERM=$TERM ANDROID_DATA=/data PATH=$PATH:/data/data/com.termux/files/usr/bin:/data/data/com.termux/files/usr/bin/applets"
        	PROOTSTMNTU="${PROOTSTMNT//--link2symlink }"
 }
 _PR00TSTRING_


### PR DESCRIPTION
This appends Termux's $PATH to the end of TermuxArch's $PATH. Since we're appending at the end, Termux's executables will be used as a last resort. This means:

- This will allow executing of Termux:API commands without needing to type the full path.

- Arch packages that don't work well in the Android environment (e.g. git which fails to commit on android file system) can be uninstalled and users can install one of the android tailored Termux packages (Termux's version of git works)