### PR TITLE
add the bindpoints regardless of if termux-api is installled

### DIFF
--- a/knownconfigurations.bash
+++ b/knownconfigurations.bash
@@ -77,12 +77,9 @@ _PR00TSTRING_() {
        	if [[ ! -r /proc/stat ]] ; then
 	       	PROOTSTMNT+="-b $INSTALLDIR/var/binds/fbindprocstat:/proc/stat " 
 	fi
-	# Add termux:api commands to the proot if installed ($PREFIX/libexec/termux-api must exist)
-	# see https://github.com/termux/termux-api/issues/140#issuecomment-605500089
+	# Add termux:api commands to the proot
 	# The user can then call it with e.g. /data/data/com.termux/files/usr/bin/termux-toast 'hello' 
-	if [ -x "$PREFIX/libexec/termux-api" ] ; then 
-		PROOTSTMNT+="-b $PREFIX -b /property_contexts -b /system/  "
-	fi
+	PROOTSTMNT+="-b $PREFIX -b /property_contexts -b /system/  "
        	if [[ -n "$(ls -A "$INSTALLDIR"/var/binds/*.prs)" ]] ; then
 	       	for PRSFILES in "$INSTALLDIR"/var/binds/*.prs ; do
 		       	. "$PRSFILES"


### PR DESCRIPTION
I believe I made a wrong decision in my original PR: These bind points can and should be added to the proot statement regardless of if the `termux-api` package is installed. AFAICT there's no reason not to have them. Doing it this way will allow the commands to work regardless of what was installed first (TermuxArch or the termux-api package). In the old PR, if TermuxArch was installed before the `termux-api` package, then the commands would not work. The way to fix that situation was to run `setupTermuxArch.bash refresh` which is not a self-evident solution.

P.S. sorry for so many PR's at once. They all address separate, mutually compatible features.