### PR TITLE
move termux PATH declaration to bashrc

### DIFF
--- a/archlinuxconfig.bash
+++ b/archlinuxconfig.bash
@@ -93,6 +93,8 @@ _ADDbashrc_() {
 	alias pcs='pacman -S --color=always'
 	alias pcss='pacman -Ss --color=always'
 	alias q='exit'
+	# Use executables in Termux's PATH as a last resort
+	PATH=\$PATH:/data/data/com.termux/files/usr/bin:/data/data/com.termux/files/usr/bin/applets
 	EOM
 	if [ -e "$HOME"/.bashrc ] ; then
 		grep proxy "$HOME"/.bashrc | grep "export" >>  root/.bashrc 2>/dev/null ||:

--- a/knownconfigurations.bash
+++ b/knownconfigurations.bash
@@ -87,7 +87,7 @@ _PR00TSTRING_() {
        	fi
        	PROOTSTMNT+="-b /proc/self/fd/1:/dev/stdout "
        	PROOTSTMNT+="-b /proc/self/fd/2:/dev/stderr "
-       	PROOTSTMNT+="-b \"\$ANDROID_DATA\" -b /dev/ -b \"\$EXTERNAL_STORAGE\" -b \"\$HOME\" -b /proc/ -b /storage/ -b /sys/ -w \"\$PWD\" /usr/bin/env -i HOME=/root TERM=$TERM ANDROID_DATA=/data PATH=$PATH:/data/data/com.termux/files/usr/bin:/data/data/com.termux/files/usr/bin/applets"
+       	PROOTSTMNT+="-b \"\$ANDROID_DATA\" -b /dev/ -b \"\$EXTERNAL_STORAGE\" -b \"\$HOME\" -b /proc/ -b /storage/ -b /sys/ -w \"\$PWD\" /usr/bin/env -i HOME=/root TERM=$TERM ANDROID_DATA=/data "
        	PROOTSTMNTU="${PROOTSTMNT//--link2symlink }"
 }
 _PR00TSTRING_


### PR DESCRIPTION
Fixing something I broke in the Termux $PATH PR: Termux executables were given higher priority than some Arch executables and there were duplicate entries. By moving the PATH declaration to bashrc, this ensures the Termux PATH comes after. The corrected PATH becomes `/root/bin:/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/bin/site_perl:/usr/bin/vendor_perl:/usr/bin/core_perl:/data/data/com.termux/files/usr/bin:/data/data/com.termux/files/usr/bin/applets` 

Tested on a fresh install